### PR TITLE
rollback changes to import React

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-icons",
-  "version": "0.1.14-a4",
+  "version": "0.1.14-a6",
   "description": "Self-made icons",
   "main": "lib/jimo-icon.js",
   "types": "./lib/jimo-icon.d.ts",

--- a/src/jimo-icon.tsx
+++ b/src/jimo-icon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import { Component, CSSProperties } from "react";
 import { cx } from "emotion";
 


### PR DESCRIPTION
Without `*`, the generated code contain `react_1.default`, which is `undefined`. Rollback code to fix.
